### PR TITLE
Fix: additional tag/dependency issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "torrent-discovery",
   "description": "Discover BitTorrent and WebTorrent peers",
-  "version": "9.2.0-arc-3",
+  "version": "9.2.0-arc-5",
   "author": {
     "name": "WebTorrent, LLC",
     "email": "feross@webtorrent.io",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "torrent-discovery",
   "description": "Discover BitTorrent and WebTorrent peers",
-  "version": "9.2.0-arc-5",
+  "version": "9.2.0-arc-6",
   "author": {
     "name": "WebTorrent, LLC",
     "email": "feross@webtorrent.io",
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "bittorrent-dht": "^9.0.0",
-    "bittorrent-tracker": "git+https://github.com/guanzo/bittorrent-tracker.git#v9.14.2-arc-3",
+    "bittorrent-tracker": "git+https://github.com/guanzo/bittorrent-tracker.git#v9.14.2-arc-4",
     "debug": "^4.0.0",
     "run-parallel": "^1.1.2"
   },


### PR DESCRIPTION
The dependency `bittorrent-tracker` had the same out of synch tags, necessitating a new release for it, and for this.